### PR TITLE
fix: ProductRepository 변경사항 반영 (Cart addItem)

### DIFF
--- a/src/main/java/com/babjo/deliverycommerce/domain/cart/service/CartService.java
+++ b/src/main/java/com/babjo/deliverycommerce/domain/cart/service/CartService.java
@@ -9,7 +9,7 @@ import com.babjo.deliverycommerce.domain.cart.entity.CartItem;
 import com.babjo.deliverycommerce.domain.cart.repository.CartItemRepository;
 import com.babjo.deliverycommerce.domain.cart.repository.CartRepository;
 import com.babjo.deliverycommerce.domain.product.entity.Product;
-import com.babjo.deliverycommerce.domain.product.repository.ProductRespository;
+import com.babjo.deliverycommerce.domain.product.repository.ProductRepository;
 import com.babjo.deliverycommerce.global.exception.CustomException;
 import com.babjo.deliverycommerce.global.exception.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
@@ -27,12 +27,12 @@ public class CartService {
 
     private final CartRepository cartRepository;
     private final CartItemRepository cartItemRepository;
-    private final ProductRespository productRespository;
+    private final ProductRepository productRepository;
 
-    public CartService(CartRepository cartRepository, CartItemRepository cartItemRepository, ProductRespository productRespository) {
+    public CartService(CartRepository cartRepository, CartItemRepository cartItemRepository, ProductRepository productRepository) {
         this.cartRepository = cartRepository;
         this.cartItemRepository = cartItemRepository;
-        this.productRespository = productRespository;
+        this.productRepository = productRepository;
     }
 
     public CartResponseDto getMyCart(Long userId) {
@@ -136,7 +136,8 @@ public class CartService {
         validateQuantity(quantity);
 
         /*상품 존재/ 삭제 여부 확인 (deletedAt is null)*/
-        Product product = productRespository.findByProductIdAndDeletedAtIsNull(productId)
+        Product product = productRepository.findById(productId)
+                .filter(p -> !p.isDeleted())
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
         /*내 장바구니 조회(없으면  생성)*/

--- a/src/test/java/com/babjo/deliverycommerce/domain/cart/CartServiceTest.java
+++ b/src/test/java/com/babjo/deliverycommerce/domain/cart/CartServiceTest.java
@@ -2,7 +2,6 @@ package com.babjo.deliverycommerce.domain.cart;
 
 import com.babjo.deliverycommerce.domain.cart.dto.CartItemAddRequestDto;
 import com.babjo.deliverycommerce.domain.cart.dto.CartItemQuantityUpdateRequestDto;
-import com.babjo.deliverycommerce.domain.cart.dto.CartItemResponseDto;
 import com.babjo.deliverycommerce.domain.cart.dto.CartResponseDto;
 import com.babjo.deliverycommerce.domain.cart.entity.Cart;
 import com.babjo.deliverycommerce.domain.cart.entity.CartItem;
@@ -10,7 +9,7 @@ import com.babjo.deliverycommerce.domain.cart.repository.CartItemRepository;
 import com.babjo.deliverycommerce.domain.cart.repository.CartRepository;
 import com.babjo.deliverycommerce.domain.cart.service.CartService;
 import com.babjo.deliverycommerce.domain.product.entity.Product;
-import com.babjo.deliverycommerce.domain.product.repository.ProductRespository;
+import com.babjo.deliverycommerce.domain.product.repository.ProductRepository;
 import com.babjo.deliverycommerce.global.exception.CustomException;
 import com.babjo.deliverycommerce.global.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +25,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -44,7 +44,7 @@ public class CartServiceTest {
     private CartItemRepository cartItemRepository;
 
     @Mock
-    private ProductRespository productRespository;
+    private ProductRepository productRepository;
 
     @InjectMocks
     private CartService cartService;
@@ -363,7 +363,7 @@ public class CartServiceTest {
 
             CartItemAddRequestDto request = 상품추가요청(productId, 2);
 
-            given(productRespository.findByProductIdAndDeletedAtIsNull(productId)).willReturn(Optional.empty());
+            given(productRepository.findById(productId)).willReturn(Optional.empty());
 
             //when & then
             assertThatThrownBy(() -> cartService.addItem(userId, request))
@@ -384,7 +384,7 @@ public class CartServiceTest {
 
             //상품 존재
             Product product = mock(Product.class);
-            given(productRespository.findByProductIdAndDeletedAtIsNull(productId)).willReturn(Optional.of(product));
+            given(productRepository.findById(productId)).willReturn(Optional.of(product));
 
             // 장바구니 없음
             given(cartRepository.findByUserIdAndDeletedAtIsNull(userId)).willReturn(Optional.empty());
@@ -429,7 +429,7 @@ public class CartServiceTest {
 
             // 상품 존재
             Product product = mock(Product.class);
-            given(productRespository.findByProductIdAndDeletedAtIsNull(productId)).willReturn(Optional.of(product));
+            given(productRepository.findById(productId)).willReturn(Optional.of(product));
 
             // 장바구니 존재
             Cart cart = Cart.create(userId, storeId);
@@ -462,7 +462,7 @@ public class CartServiceTest {
             CartItemAddRequestDto request = 상품추가요청(productId, null);
 
             Product product = mock(Product.class);
-            given(productRespository.findByProductIdAndDeletedAtIsNull(productId)).willReturn(Optional.of(product));
+            given(productRepository.findById(productId)).willReturn(Optional.of(product));
 
             Cart cart = Cart.create(userId, null);
             given(cartRepository.findByUserIdAndDeletedAtIsNull(userId)).willReturn(Optional.of(cart));


### PR DESCRIPTION
## 작업 내용
- ProductRepository 메서드 변경에 맞춰 Cart `addItem` 상품 조회 로직 수정
  - 기존 `findByProductIdAndDeletedAtIsNull` 사용 제거
  - `findById` 기반 조회 + soft delete 필터링으로 대체
- 관련 테스트 수정(CartServiceTest addItem 케이스)

