### PR TITLE
test:반복 패턴 테스트 케이스 정리

### DIFF
--- a/src/test/java/com/babjo/deliverycommerce/domain/user/UserControllerTest.java
+++ b/src/test/java/com/babjo/deliverycommerce/domain/user/UserControllerTest.java
@@ -297,14 +297,6 @@ public class UserControllerTest {
                             .with(user(new UserPrincipal(1L, "testuser", "ROLE_CUSTOMER"))))
                     .andExpect(status().isForbidden());
         }
-
-        @Test
-        @DisplayName("미인증 사용자 - 401 반환")
-        void whenUnauthenticated() throws Exception {
-            // when & then
-            mockMvc.perform(get("/v1/users/1"))
-                    .andExpect(status().isUnauthorized());
-        }
     }
 
     // ========================
@@ -334,14 +326,6 @@ public class UserControllerTest {
             // when & then
             mockMvc.perform(get("/v1/users"))
                     .andExpect(status().isForbidden());
-        }
-
-        @Test
-        @DisplayName("미인증 사용자 - 401 반환")
-        void whenUnauthenticated() throws Exception {
-            // when & then
-            mockMvc.perform(get("/v1/users"))
-                    .andExpect(status().isUnauthorized());
         }
     }
 
@@ -391,23 +375,6 @@ public class UserControllerTest {
                             .content(body))
                     .andExpect(status().isBadRequest());
         }
-
-        @Test
-        @DisplayName("미인증 사용자 - 401 반환")
-        void whenUnauthenticated() throws Exception {
-            // given
-            String body = """
-                    {
-                        "prePw": "Password1!"
-                    }
-                    """;
-
-            // when & then
-            mockMvc.perform(patch("/v1/users/me")
-                            .contentType("application/json")
-                            .content(body))
-                    .andExpect(status().isUnauthorized());
-        }
     }
 
     // ========================
@@ -454,23 +421,6 @@ public class UserControllerTest {
                             .contentType("application/json")
                             .content(body))
                     .andExpect(status().isForbidden());
-        }
-
-        @Test
-        @DisplayName("미인증 사용자 - 401 반환")
-        void whenUnauthenticated() throws Exception {
-            // given
-            String body = """
-                    {
-                        "nickname": "수정된닉네임"
-                    }
-                    """;
-
-            // when & then
-            mockMvc.perform(patch("/v1/users/1")
-                            .contentType("application/json")
-                            .content(body))
-                    .andExpect(status().isUnauthorized());
         }
     }
 
@@ -524,24 +474,6 @@ public class UserControllerTest {
                             .header("Authorization", "Bearer token"))
                     .andExpect(status().isBadRequest());
         }
-
-        @Test
-        @DisplayName("미인증 사용자 - 401 반환")
-        void whenUnauthenticated() throws Exception {
-            // given
-            String body = """
-                    {
-                        "password": "Password1!"
-                    }
-                    """;
-
-            // when & then
-            mockMvc.perform(post("/v1/users/me")
-                            .contentType("application/json")
-                            .content(body)
-                            .header("Authorization", "Bearer token"))
-                    .andExpect(status().isUnauthorized());
-        }
     }
 
     // ========================
@@ -572,14 +504,6 @@ public class UserControllerTest {
             // when & then
             mockMvc.perform(delete("/v1/users/2"))
                     .andExpect(status().isForbidden());
-        }
-
-        @Test
-        @DisplayName("미인증 사용자 - 401 반환")
-        void whenUnauthenticated() throws Exception {
-            // when & then
-            mockMvc.perform(delete("/v1/users/2"))
-                    .andExpect(status().isUnauthorized());
         }
     }
 
@@ -646,23 +570,6 @@ public class UserControllerTest {
                             .contentType("application/json")
                             .content(body))
                     .andExpect(status().isBadRequest());
-        }
-
-        @Test
-        @DisplayName("미인증 사용자 - 401 반환")
-        void whenUnauthenticated() throws Exception {
-            // given
-            String body = """
-                    {
-                        "role": "CUSTOMER"
-                    }
-                    """;
-
-            // when & then
-            mockMvc.perform(patch("/v1/users/2/role")
-                            .contentType("application/json")
-                            .content(body))
-                    .andExpect(status().isUnauthorized());
         }
     }
 
@@ -744,28 +651,6 @@ public class UserControllerTest {
                             .contentType("application/json")
                             .content(body))
                     .andExpect(status().isBadRequest());
-        }
-
-        @Test
-        @DisplayName("미인증 사용자 - 401 반환")
-        void whenUnauthenticated() throws Exception {
-            // given
-            String body = """
-                    {
-                        "username": "newuser1",
-                        "password": "Password1!",
-                        "passwordConfirm": "Password1!",
-                        "email": "newuser@test.com",
-                        "nickname": "새유저",
-                        "role": "MANAGER"
-                    }
-                    """;
-
-            // when & then
-            mockMvc.perform(post("/v1/users/admin")
-                            .contentType("application/json")
-                            .content(body))
-                    .andExpect(status().isUnauthorized());
         }
     }
 }

--- a/src/test/java/com/babjo/deliverycommerce/domain/user/UserRepositoryTest.java
+++ b/src/test/java/com/babjo/deliverycommerce/domain/user/UserRepositoryTest.java
@@ -13,8 +13,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
@@ -41,29 +39,6 @@ public class UserRepositoryTest {
     class ExistsByUsernameAll {
 
         @Test
-        @DisplayName("존재하는 아이디면 true를 반환한다")
-        void withExistingUsername() {
-            // given
-            userRepository.save(createUser("testuser", "test@test.com"));
-
-            // when
-            boolean result = userRepository.existsByUsernameAll("testuser");
-
-            // then
-            assertThat(result).isTrue();
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 아이디면 false를 반환한다")
-        void withNonExistentUsername() {
-            // when
-            boolean result = userRepository.existsByUsernameAll("notestuser");
-
-            // then
-            assertThat(result).isFalse();
-        }
-
-        @Test
         @DisplayName("탈퇴한 사용자의 아이디여도 true를 반환한다")
         void withDeletedUserUsername() {
             // given
@@ -80,32 +55,11 @@ public class UserRepositoryTest {
         }
     }
 
+    // '탈퇴한 사용자도 포함하는가'에 대한 커스텀 쿼리를 검증하는 것이 핵심이므로, 프레임워크가 검증한 케이스는 제외합니다.
+
     @Nested
     @DisplayName("existsByEmailAll")
     class ExistsByEmailAll {
-
-        @Test
-        @DisplayName("존재하는 이메일이면 true를 반환한다")
-        void withExistingEmail() {
-            // given
-            userRepository.save(createUser("testuser", "test@test.com"));
-
-            // when
-            boolean result = userRepository.existsByEmailAll("test@test.com");
-
-            // then
-            assertThat(result).isTrue();
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 email이면 false를 반환한다")
-        void withNonExistentEmail() {
-            // when
-            boolean result = userRepository.existsByEmailAll("noexistent@test.com");
-
-            // then
-            assertThat(result).isFalse();
-        }
 
         @Test
         @DisplayName("탈퇴한 사용자의 이메일이어도 true를 반환한다")
@@ -121,36 +75,6 @@ public class UserRepositoryTest {
 
             // then
             assertThat(result).isTrue();
-        }
-    }
-
-    @Nested
-    @DisplayName("findByUsername")
-    class FindByUsername {
-
-        @Test
-        @DisplayName("존재하는 아이디면 그 User를 반환한다")
-        void withExistingUsername() {
-            // given
-            userRepository.save(createUser("testuser", "test@test.com"));
-
-            // when
-            Optional<User> result = userRepository.findByUsername("testuser");
-
-            // then
-            assertThat(result).isPresent();
-            assertThat(result.get().getUsername()).isEqualTo("testuser");
-            assertThat(result.get().getEmail()).isEqualTo("test@test.com");
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 아이디면 Optional.empty()를 반환한다")
-        void withNonExistentUsername() {
-            // when
-            Optional<User> result = userRepository.findByUsername("nonexistent");
-
-            // then
-            assertThat(result).isEmpty();
         }
     }
 }

--- a/src/test/java/com/babjo/deliverycommerce/domain/user/UserServiceTest.java
+++ b/src/test/java/com/babjo/deliverycommerce/domain/user/UserServiceTest.java
@@ -272,23 +272,6 @@ class UserServiceTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 userId - USER_NOT_FOUND 예외 발생")
-        void withNonExistentUser() {
-            // given
-            String refreshToken = "validRefreshToken";
-            Claims mockClaims = mock(Claims.class);
-            given(mockClaims.getSubject()).willReturn("999");
-            given(jwtUtil.getUserInfoFromToken(refreshToken)).willReturn(mockClaims);
-            given(userRepository.findById(999L)).willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> userService.reissue(refreshToken))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
-        }
-
-        @Test
         @DisplayName("탈퇴한 사용자 - WITHDRAWN_USER 예외 발생")
         void withWithdrawnUser() {
             // given
@@ -362,33 +345,6 @@ class UserServiceTest {
             // then
             assertThat(response.getUsername()).isEqualTo("testuser1");
         }
-
-        @Test
-        @DisplayName("존재하지 않는 userId - USER_NOT_FOUND 예외 발생")
-        void withNonExistentUser() {
-            // given
-            given(userRepository.findById(999L)).willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> userService.getUser(999L))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
-        }
-
-        @Test
-        @DisplayName("탈퇴한 사용자 - WITHDRAWN_USER 예외 발생")
-        void withWithdrawnUser() {
-            // given
-            User user = createDeletedUser(1L, "testuser1", UserEnumRole.CUSTOMER);
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-
-            // when & then
-            assertThatThrownBy(() -> userService.getUser(1L))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.WITHDRAWN_USER);
-        }
     }
 
     @Nested
@@ -420,35 +376,6 @@ class UserServiceTest {
 
             // then
             assertThat(response.getUsername()).isEqualTo("testuser1");
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 userId - USER_NOT_FOUND 예외 발생")
-        void withNonExistentUser() {
-            // given
-            UserUpdateRequestDto request = createUpdateRequest(null, "Password1!", null, null, null);
-            given(userRepository.findById(999L)).willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> userService.updateUser(request, 999L))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
-        }
-
-        @Test
-        @DisplayName("탈퇴한 사용자 - WITHDRAWN_USER 예외 발생")
-        void withWithdrawnUser() {
-            // given
-            User user = createDeletedUser(1L, "testuser1", UserEnumRole.CUSTOMER);
-            UserUpdateRequestDto request = createUpdateRequest(null, "Password1!", null, null, null);
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-
-            // when & then
-            assertThatThrownBy(() -> userService.updateUser(request, 1L))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.WITHDRAWN_USER);
         }
 
         @Test
@@ -538,33 +465,6 @@ class UserServiceTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 userId - USER_NOT_FOUND 예외 발생")
-        void withNonExistentUser() {
-            // given
-            given(userRepository.findById(999L)).willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> userService.deleteUser(999L, "Password1!"))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
-        }
-
-        @Test
-        @DisplayName("탈퇴한 사용자 - WITHDRAWN_USER 예외 발생")
-        void withWithdrawnUser() {
-            // given
-            User user = createDeletedUser(1L, "testuser1", UserEnumRole.CUSTOMER);
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-
-            // when & then
-            assertThatThrownBy(() -> userService.deleteUser(1L, "Password1!"))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.WITHDRAWN_USER);
-        }
-
-        @Test
         @DisplayName("비밀번호 불일치 - INVALID_PASSWORD 예외 발생")
         void withInvalidPassword() {
             // given
@@ -609,33 +509,6 @@ class UserServiceTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 userId - USER_NOT_FOUND 예외 발생")
-        void withNonExistentUser() {
-            // given
-            given(userRepository.findById(999L)).willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> userService.adminDeleteUser(999L, 1L))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
-        }
-
-        @Test
-        @DisplayName("탈퇴한 사용자 - WITHDRAWN_USER 예외 발생")
-        void withWithdrawnUser() {
-            // given
-            User user = createDeletedUser(2L, "targetuser", UserEnumRole.CUSTOMER);
-            given(userRepository.findById(2L)).willReturn(Optional.of(user));
-
-            // when & then
-            assertThatThrownBy(() -> userService.adminDeleteUser(2L, 1L))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.WITHDRAWN_USER);
-        }
-
-        @Test
         @DisplayName("MASTER 권한 대상 - FORBIDDEN 예외 발생")
         void whenTargetIsMaster() {
             // given
@@ -676,33 +549,6 @@ class UserServiceTest {
                     .isInstanceOf(CustomException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.CANNOT_UPDATE_ROLE_SELF);
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 userId - USER_NOT_FOUND 예외 발생")
-        void withNonExistentUser() {
-            // given
-            given(userRepository.findById(999L)).willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> userService.adminUpdateRoleUser(999L, 1L, "OWNER"))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
-        }
-
-        @Test
-        @DisplayName("탈퇴한 사용자 - WITHDRAWN_USER 예외 발생")
-        void withWithdrawnUser() {
-            // given
-            User user = createDeletedUser(2L, "targetuser", UserEnumRole.CUSTOMER);
-            given(userRepository.findById(2L)).willReturn(Optional.of(user));
-
-            // when & then
-            assertThatThrownBy(() -> userService.adminUpdateRoleUser(2L, 1L, "OWNER"))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.WITHDRAWN_USER);
         }
 
         @Test
@@ -752,50 +598,6 @@ class UserServiceTest {
             // then
             assertThat(response.getUsername()).isEqualTo("manager1");
             assertThat(response.getRole()).isEqualTo("MANAGER");
-        }
-
-        @Test
-        @DisplayName("비밀번호 확인 불일치 - PASSWORD_MISMATCH 예외 발생")
-        void withPasswordMismatch() {
-            // given
-            AdminSignupRequestDto request = createAdminSignupRequest("manager1", "Password1!", "WrongPassword1!", "MANAGER");
-
-            // when & then
-            assertThatThrownBy(() -> userService.adminSignup(request, 1L))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.PASSWORD_MISMATCH);
-        }
-
-        @Test
-        @DisplayName("username 중복 - DUPLICATE_USERNAME 예외 발생")
-        void withDuplicateUsername() {
-            // given
-            AdminSignupRequestDto request = createAdminSignupRequest("manager1", "Password1!", "Password1!", "MANAGER");
-
-            given(userRepository.existsByUsernameAll(request.getUsername())).willReturn(true);
-
-            // when & then
-            assertThatThrownBy(() -> userService.adminSignup(request, 1L))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.DUPLICATE_USERNAME);
-        }
-
-        @Test
-        @DisplayName("email 중복 - DUPLICATE_EMAIL 예외 발생")
-        void withDuplicateEmail() {
-            // given
-            AdminSignupRequestDto request = createAdminSignupRequest("manager1", "Password1!", "Password1!", "MANAGER");
-
-            given(userRepository.existsByUsernameAll(request.getUsername())).willReturn(false);
-            given(userRepository.existsByEmailAll(request.getEmail())).willReturn(true);
-
-            // when & then
-            assertThatThrownBy(() -> userService.adminSignup(request, 1L))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.DUPLICATE_EMAIL);
         }
     }
 }


### PR DESCRIPTION
## 🌱 설명
> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.
- 예) 반복 패턴 테스트 케이스 정리

## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- 예) #7 

## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat : 새로운 기능 추가
- [ ] fix : 버그 수정
- [ ] !hotfix : 급하게 치명적인 버그 수정
- [x] refactor : 리팩토링
- [ ] chore : 빌드 설정, 의존성 업데이트 등
- [ ] docs : 문서 수정
- [ ] comment : 필요한 주석 추가 및 변경
- [ ] rename : 파일 또는 폴더 명을 수정하거나 옮기는 작업
- [ ] remove : 파일을 삭제하는 작업
- [x] test : 테스트 코드, 리팩토링 테스트 코드 추가


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)
 - USER 도메인 테스트 코드에서 아래 기준으로 중복 케이스를 정리했습니다.

   UserServiceTest
  - `USER_NOT_FOUND`, `WITHDRAWN_USER` 체크는 모든 메서드가 동일한 패턴으로 동작하므로,
    대표 케이스(login, reissue)에서만 검증하고 나머지에서는 제거했습니다.
  - `adminSignup`의 중복 검증(PASSWORD_MISMATCH, DUPLICATE_*)은
    `signup`에서 이미 검증된 로직이므로 제거했습니다.

  UserControllerTest
  - `authenticated()` 설정된 엔드포인트의 미인증 401 케이스는
    Security 설정 레벨의 동작이므로 logout 하나만 대표로 남겼습니다.

  UserRepositoryTest
  - `existsByUsernameAll`, `existsByEmailAll`은 "탈퇴한 사용자도 포함하는가"가
    커스텀 쿼리의 핵심이므로, 해당 케이스만 유지했습니다.