### PR TITLE
[fix] ProductServiceImplTest 수정 및 User Role Enum 처리

### DIFF
--- a/src/main/java/com/babjo/deliverycommerce/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/babjo/deliverycommerce/domain/product/repository/ProductRepository.java
@@ -13,6 +13,9 @@ public interface ProductRepository extends JpaRepository<Product, UUID> {
     // 단건 조회(삭제 제외)
     Optional<Product> findByProductIdAndStore_StoreIdAndDeletedAtIsNull(UUID storeId, UUID productId);
 
+    // 단건 조회
+    Optional <Product> findByProductIdAndStore_StoreId(UUID storeId, UUID productId);
+
     // 가게별 전체 조회(삭제 제외)
     Page<Product> findAllByStore_StoreIdAndDeletedAtIsNull(UUID storeId, Pageable pageable);
 

--- a/src/main/java/com/babjo/deliverycommerce/domain/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/babjo/deliverycommerce/domain/product/service/ProductServiceImpl.java
@@ -2,6 +2,7 @@ package com.babjo.deliverycommerce.domain.product.service;
 
 import com.babjo.deliverycommerce.domain.store.entity.Store;
 import com.babjo.deliverycommerce.domain.store.repository.StoreRepository;
+import com.babjo.deliverycommerce.global.common.enums.UserEnumRole;
 import com.babjo.deliverycommerce.global.exception.CustomException;
 import com.babjo.deliverycommerce.global.exception.ErrorCode;
 import com.babjo.deliverycommerce.global.security.UserPrincipal;
@@ -147,7 +148,13 @@ public class ProductServiceImpl implements ProductService {
     @Transactional
     public ProductResponseDto get(UUID storeId, UUID productId, UserPrincipal user) {
 
-        Product product = getActiveProduct(storeId, productId);
+        Product product = productRepository.findByProductIdAndStore_StoreId(storeId, productId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        // 삭제 상품 조회 차단
+        if (product.isDeleted()) {
+            throw new CustomException(ErrorCode.PRODUCT_DELETED);
+        }
 
         // 숨김 상품 접근 제어
         if(product.isProductHide() && !canViewHiddenProduct(storeId, user)) {
@@ -218,11 +225,11 @@ public class ProductServiceImpl implements ProductService {
 
         String role= user.getRole();
 
-        if(role.equals("MANAGER") || role.equals("MASTER")) {
+        if(role.equals(UserEnumRole.Authority.MANAGER) || role.equals(UserEnumRole.Authority.MASTER)) {
             return;
         }
 
-        if (role.equals("OWNER")) {
+        if (role.equals(UserEnumRole.Authority.OWNER)) {
             Store store = getActiveStore(storeId);
             Long ownerUserId = store.getCreatedBy();
 
@@ -247,11 +254,11 @@ public class ProductServiceImpl implements ProductService {
 
         String role = user.getRole();
 
-        if(role.equals("MANAGER") || role.equals("MASTER")) {
+        if(role.equals(UserEnumRole.Authority.MANAGER) || role.equals(UserEnumRole.Authority.MASTER)) {
             return true;
         }
 
-        if(role.equals("OWNER")) {
+        if(role.equals(UserEnumRole.Authority.OWNER)) {
             Store store = getActiveStore(storeId);
             Long ownerId = store.getCreatedBy();
             return ownerId != null && ownerId.equals(user.getUserId());

--- a/src/test/java/com/babjo/deliverycommerce/domain/product/ProductServiceImplTest.java
+++ b/src/test/java/com/babjo/deliverycommerce/domain/product/ProductServiceImplTest.java
@@ -5,6 +5,7 @@ import com.babjo.deliverycommerce.domain.product.service.AiDescriptionService;
 import com.babjo.deliverycommerce.domain.product.service.ProductServiceImpl;
 import com.babjo.deliverycommerce.domain.store.entity.Store;
 import com.babjo.deliverycommerce.domain.store.repository.StoreRepository;
+import com.babjo.deliverycommerce.global.common.enums.UserEnumRole;
 import com.babjo.deliverycommerce.global.exception.CustomException;
 import com.babjo.deliverycommerce.global.exception.ErrorCode;
 import com.babjo.deliverycommerce.global.security.UserPrincipal;
@@ -60,7 +61,7 @@ class ProductServiceImplTest {
         );
 
         UserPrincipal user = mock(UserPrincipal.class);
-        when(user.getRole()).thenReturn("OWNER");
+        when(user.getRole()).thenReturn(UserEnumRole.Authority.OWNER);
         when(user.getUserId()).thenReturn(2L);
 
         Store store = mock(Store.class);
@@ -80,7 +81,7 @@ class ProductServiceImplTest {
     @Test
     void getProduct_notFound() {
         // given
-        when(productRepository.findByProductIdAndStore_StoreIdAndDeletedAtIsNull(storeId, productId))
+        when(productRepository.findByProductIdAndStore_StoreId(storeId, productId))
                 .thenReturn(Optional.empty());
 
         UserPrincipal user = mock(UserPrincipal.class);
@@ -109,11 +110,11 @@ class ProductServiceImplTest {
 
         product.hide();
 
-        when(productRepository.findByProductIdAndStore_StoreIdAndDeletedAtIsNull(storeId, productId))
+        when(productRepository.findByProductIdAndStore_StoreId(storeId, productId))
                 .thenReturn(Optional.of(product));
 
         UserPrincipal user = mock(UserPrincipal.class);
-        when(user.getRole()).thenReturn("CUSTOMER");
+        when(user.getRole()).thenReturn(UserEnumRole.Authority.CUSTOMER);
 
         // when & then
         assertThatThrownBy(() -> productService.get(storeId, productId, user))
@@ -142,7 +143,7 @@ class ProductServiceImplTest {
         // 현재 서비스의 getActiveProduct()는 findByProductIdAndDeletedAtIsNull로 조회해서
         // 삭제된 상품은 보통 Optional.empty가 되어야 자연스러움.
         // 하지만 지금 코드에는 deletedAt 체크도 있으니 테스트에서 해당 흐름을 강제로 태우려면 Optional.of(...)로 준다.
-        when(productRepository.findByProductIdAndStore_StoreIdAndDeletedAtIsNull(storeId, productId))
+        when(productRepository.findByProductIdAndStore_StoreId(storeId, productId))
                 .thenReturn(Optional.of(product));
 
         UserPrincipal user = mock(UserPrincipal.class);
@@ -170,11 +171,11 @@ class ProductServiceImplTest {
                 .build();
         product.hide();
 
-        when(productRepository.findByProductIdAndStore_StoreIdAndDeletedAtIsNull(storeId, productId))
+        when(productRepository.findByProductIdAndStore_StoreId(storeId, productId))
                 .thenReturn(Optional.of(product));
 
         UserPrincipal user = mock(UserPrincipal.class);
-        when(user.getRole()).thenReturn("OWNER");
+        when(user.getRole()).thenReturn(UserEnumRole.Authority.OWNER);
         when(user.getUserId()).thenReturn(2L);
 
         Store store = mock(Store.class);
@@ -204,11 +205,11 @@ class ProductServiceImplTest {
                 .build();
         product.hide();
 
-        when(productRepository.findByProductIdAndStore_StoreIdAndDeletedAtIsNull(storeId, productId))
+        when(productRepository.findByProductIdAndStore_StoreId(storeId, productId))
                 .thenReturn(Optional.of(product));
 
         UserPrincipal user = mock(UserPrincipal.class);
-        when(user.getRole()).thenReturn("OWNER");
+        when(user.getRole()).thenReturn(UserEnumRole.Authority.OWNER);
         when(user.getUserId()).thenReturn(2L);
 
         Store store = mock(Store.class);
@@ -235,11 +236,11 @@ class ProductServiceImplTest {
                 .build();
         product.hide();
 
-        when(productRepository.findByProductIdAndStore_StoreIdAndDeletedAtIsNull(storeId, productId))
+        when(productRepository.findByProductIdAndStore_StoreId(storeId, productId))
                 .thenReturn(Optional.of(product));
 
         UserPrincipal user = mock(UserPrincipal.class);
-        when(user.getRole()).thenReturn("MANAGER");
+        when(user.getRole()).thenReturn(UserEnumRole.Authority.MANAGER);
 
         // when
         ProductResponseDto response = productService.get(storeId, productId, user);
@@ -270,7 +271,7 @@ class ProductServiceImplTest {
                 .thenReturn("트러플 향 가득한 부드러운 크림 파스타!");
 
         UserPrincipal user = mock(UserPrincipal.class);
-        when(user.getRole()).thenReturn("OWNER");
+        when(user.getRole()).thenReturn(UserEnumRole.Authority.OWNER);
         when(user.getUserId()).thenReturn(2L);
 
         Store store = mock(Store.class);


### PR DESCRIPTION
## 🌱 설명
- 삭제된 상품 조회 시 발생하는 예외 코드 불일치 문제를 수정했습니다.
- 기존 로직에서는 deletedAtIsNull 조건으로 조회하여 삭제된 상품이 PRODUCT_NOT_FOUND로 처리되고 있었습니다.
- 서비스 로직에서 isDeleted() 체크를 추가하여 삭제된 상품 조회 시 PRODUCT_DELETED 예외가 발생하도록 수정했습니다.
- validateStoreAccess() 및 canViewHiddenProduct()에서 User Role 문자열 비교 문제를 수정했습니다.

## 📌 관련 이슈
- close #41 

## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat : 새로운 기능 추가
- [x] fix : 버그 수정
- [ ] !hotfix : 급하게 치명적인 버그 수정
- [ ] refactor : 리팩토링
- [ ] chore : 빌드 설정, 의존성 업데이트 등
- [ ] docs : 문서 수정
- [ ] comment : 필요한 주석 추가 및 변경
- [ ] rename : 파일 또는 폴더 명을 수정하거나 옮기는 작업
- [ ] remove : 파일을 삭제하는 작업
- [ ] test : 테스트 코드, 리팩토링 테스트 코드 추가


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명

### 삭제 상품 조회 로직 변경

기존 로직
```java
findByProductIdAndStore_StoreIdAndDeletedAtIsNull(...)
```

삭제된 상품이 조회되지 않아 PRODUCT_NOT_FOUND 예외가 발생하는 문제가 있었습니다.

수정 후
1. 상품 조회
2. isDeleted() 체크
3. 삭제 상품이면 PRODUCT_DELETED 예외 발생

```java
if(product.isDeleted()) {
    throw new CustomException(ErrorCode.PRODUCT_DELETED);
}
```

### Role 비교 로직 수정

기존
```java
if(role.equals("OWNER"))
```

실제 Security Role
```
ROLE_OWNER
ROLE_MANAGER
ROLE_MASTER
```

문자열 불일치로 인해 권한 검증 오류가 발생할 수 있어 Role 비교 로직을 수정했습니다.